### PR TITLE
fix: Replace fmt.Sprintf("%v",v) with cast.ToString(v)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.12
 	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.13.4
+	github.com/spf13/cast v1.9.2
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -98,7 +99,6 @@ require (
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/speps/go-hashids v2.0.0+incompatible // indirect
-	github.com/spf13/cast v1.9.2 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/internal/driver/checkstatuses.go
+++ b/internal/driver/checkstatuses.go
@@ -1,22 +1,23 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2022 Intel Corporation
-// Copyright (c) 2023 IOTech Ltd
+// Copyright (c) 2023-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package driver
 
 import (
-	"fmt"
-	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
 	"net"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/IOTechSystems/onvif"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
+
+	"github.com/spf13/cast"
 )
 
 // checkStatuses loops through all registered devices and tries to determine the most accurate connection state
@@ -48,7 +49,7 @@ func (d *Driver) checkStatusOfDevice(device models.Device) {
 	// if device is unknown, and missing a MAC Address, try and determine the MAC address via the endpoint reference
 	if strings.HasPrefix(device.Name, UnknownDevicePrefix) && device.Protocols[OnvifProtocol][MACAddress] == "" {
 		if v, ok := device.Protocols[OnvifProtocol][EndpointRefAddress]; ok {
-			endpointRefAddr := fmt.Sprintf("%v", v)
+			endpointRefAddr := cast.ToString(v)
 			if endpointRefAddr != "" {
 				if mac := d.macAddressMapper.MatchEndpointRefAddressToMAC(endpointRefAddr); mac != "" {
 					// the mac address for the device was found, so set it here which will allow the

--- a/internal/driver/config.go
+++ b/internal/driver/config.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2022 Intel Corporation
-// Copyright (c) 2023 IOTech Ltd
+// Copyright (c) 2023-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,6 +12,8 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
+
+	"github.com/spf13/cast"
 )
 
 // CustomConfig holds the values for the driver configuration
@@ -72,14 +74,14 @@ func GetCameraXAddr(protocols map[string]models.ProtocolProperties) (string, err
 
 	address := ""
 	if v, ok := protocol[Address]; ok {
-		address = fmt.Sprintf("%v", v)
+		address = cast.ToString(v)
 	}
 	if address == "" {
 		return "", errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unable to load XAddr, %s Address does not exist", OnvifProtocol), nil)
 	}
 	port := ""
 	if v, ok := protocol[Port]; ok {
-		port = fmt.Sprintf("%v", v)
+		port = cast.ToString(v)
 	}
 
 	xAddr := address

--- a/internal/driver/credentials.go
+++ b/internal/driver/credentials.go
@@ -1,19 +1,20 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2022 Intel Corporation
-// Copyright (c) 2023 IOTech Ltd
+// Copyright (c) 2023-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package driver
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/IOTechSystems/onvif"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
+
+	"github.com/spf13/cast"
 )
 
 // Credentials encapsulates username, password, and AuthMode attributes.
@@ -97,7 +98,7 @@ func (d *Driver) getCredentialsForDevice(device models.Device) Credentials {
 	secretName := defaultSecretName
 	macAddress := ""
 	if v, ok := device.Protocols[OnvifProtocol][MACAddress]; ok {
-		macAddress = fmt.Sprintf("%v", v)
+		macAddress = cast.ToString(v)
 	}
 	if macAddress != "" {
 		secretName = d.macAddressMapper.TryGetSecretNameForMACAddress(macAddress, defaultSecretName)

--- a/internal/driver/custommetadata.go
+++ b/internal/driver/custommetadata.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2022 Intel Corporation
-// Copyright (c) 2023 IOTech Ltd
+// Copyright (c) 2023-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,6 +15,8 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/v4/models"
+
+	"github.com/spf13/cast"
 )
 
 func (onvifClient *OnvifClient) initCustomMetadata(device *contract.Device) {
@@ -37,7 +39,7 @@ func (onvifClient *OnvifClient) setCustomMetadata(device contract.Device, data [
 	}
 	saveDevice := device
 	for key, value := range dataObj {
-		value = strings.TrimSpace(fmt.Sprintf("%v", value))
+		value = strings.TrimSpace(cast.ToString(value))
 		key = strings.TrimSpace(key)
 		if len(key) == 0 {
 			inputErr := error.New("tried to add an empty key")

--- a/internal/driver/custommetadata_test.go
+++ b/internal/driver/custommetadata_test.go
@@ -1,6 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2022 Intel Corporation
+// Copyright (C) 2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -266,6 +267,34 @@ func TestOnvifClient_setCustomMetadata(t *testing.T) {
 			data:          "bogus",
 			expected:      contract.Device{},
 			errorExpected: true,
+		},
+		{
+			name: "happy path set (float value greater than 1e6)",
+			device: contract.Device{
+				Protocols: map[string]contract.ProtocolProperties{
+					CustomMetadata: {},
+				},
+			},
+			data: `{"FloatValue": 1000000.1}`,
+			expected: contract.Device{
+				Protocols: map[string]contract.ProtocolProperties{
+					CustomMetadata: {"FloatValue": "1000000.1"},
+				},
+			},
+		},
+		{
+			name: "happy path set (float value less than 1e-4)",
+			device: contract.Device{
+				Protocols: map[string]contract.ProtocolProperties{
+					CustomMetadata: {},
+				},
+			},
+			data: `{"FloatValue": 0.00009}`,
+			expected: contract.Device{
+				Protocols: map[string]contract.ProtocolProperties{
+					CustomMetadata: {"FloatValue": "0.00009"},
+				},
+			},
 		},
 	}
 

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2022-2023 Intel Corporation
-// Copyright (c) 2023-2024 IOTech Ltd
+// Copyright (c) 2023-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,8 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/secret"
-	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
 	"strings"
 	"sync"
 	"time"
@@ -21,13 +19,17 @@ import (
 
 	"github.com/edgexfoundry/device-onvif-camera/internal/netscan"
 	sdkModel "github.com/edgexfoundry/device-sdk-go/v4/pkg/models"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/secret"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
 
 	onvifdevice "github.com/IOTechSystems/onvif/device"
 	wsdiscovery "github.com/IOTechSystems/onvif/ws-discovery"
+
+	"github.com/spf13/cast"
 )
 
 const (
@@ -549,7 +551,7 @@ func (d *Driver) renameDevice(device models.Device, deviceInfo *onvifdevice.GetD
 	device.Name = buildDeviceName(
 		deviceInfo.Manufacturer,
 		deviceInfo.Model,
-		fmt.Sprintf("%v", device.Protocols[OnvifProtocol][EndpointRefAddress]),
+		cast.ToString(device.Protocols[OnvifProtocol][EndpointRefAddress]),
 	)
 
 	d.lc.Infof("Adding device back with the updated name '%s'", device.Name)

--- a/internal/driver/onvifclient.go
+++ b/internal/driver/onvifclient.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2022-2023 Intel Corporation
-// Copyright (c) 2023 IOTech Ltd
+// Copyright (c) 2023-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,6 +27,8 @@ import (
 	onvifdevice "github.com/IOTechSystems/onvif/device"
 	"github.com/IOTechSystems/onvif/gosoap"
 	"github.com/IOTechSystems/onvif/media"
+
+	"github.com/spf13/cast"
 )
 
 const (
@@ -345,7 +347,7 @@ func (onvifClient *OnvifClient) callCustomFunction(resourceName, functionName st
 		}
 		friendlyName := ""
 		if v, ok := device.Protocols[OnvifProtocol][FriendlyName]; ok {
-			friendlyName = fmt.Sprintf("%v", v)
+			friendlyName = cast.ToString(v)
 		}
 		cv, err = sdkModel.NewCommandValue(resourceName, common.ValueTypeString, friendlyName)
 		if err != nil {
@@ -381,7 +383,7 @@ func (onvifClient *OnvifClient) callCustomFunction(resourceName, functionName st
 		}
 		macAddress := ""
 		if v, ok := device.Protocols[OnvifProtocol][MACAddress]; ok {
-			macAddress = fmt.Sprintf("%v", v)
+			macAddress = cast.ToString(v)
 		}
 		cv, err = sdkModel.NewCommandValue(resourceName, common.ValueTypeString, macAddress)
 		if err != nil {

--- a/internal/netscan/discover.go
+++ b/internal/netscan/discover.go
@@ -1,6 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2022 Intel Corporation
+// Copyright (C) 2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,6 +19,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/spf13/cast"
 )
 
 const (
@@ -75,14 +78,14 @@ func AutoDiscover(ctx context.Context, proto ProtocolSpecificDiscovery, params P
 	portCount := len(params.ScanPorts)
 	var estimatedTimeStr string
 	if portCount == 1 {
-		estimatedTimeStr = fmt.Sprintf("%v", probeFactor*params.Timeout)
+		estimatedTimeStr = cast.ToString(probeFactor * params.Timeout)
 	} else {
-		estimatedTimeStr = fmt.Sprintf("min: %v max: %v typical: ~%v",
-			probeFactor*params.Timeout,
-			probeFactor*params.Timeout*time.Duration(portCount),
+		estimatedTimeStr = fmt.Sprintf("min: %s max: %s typical: ~%s",
+			cast.ToString(probeFactor*params.Timeout),
+			cast.ToString(probeFactor*params.Timeout*time.Duration(portCount)),
 			// typical is just a guess, but have observed it taking around 3x the timeout time when 3
 			// or more ports are scanned.
-			probeFactor*params.Timeout*time.Duration(math.Min(float64(portCount), 3)))
+			cast.ToString(probeFactor*params.Timeout*time.Duration(math.Min(float64(portCount), 3))))
 	}
 	params.Logger.Debugf("total estimated network probes: %d, async limit: %d, probe timeout: %v, estimated time: %s",
 		estimatedProbes, asyncLimit, params.Timeout, estimatedTimeStr)


### PR DESCRIPTION
Replace fmt.Sprintf("%v",v) with cast.ToString(v) to ensure consistent string conversion and avoid scientific notation for float values.

fix: #526 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

